### PR TITLE
FIX: deepen `check` depth

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -71,7 +71,7 @@ else
     branchflag="--branch $branch"
   fi
 	
-  depth=1
+  depth=500
 
   logInfo "BEGIN opendoor/git-resource assets/check ... about to call clone with depth : $depth"
   git clone --depth=$depth --single-branch $uri $branchflag $destination $tagflag


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

> What changes are being made? Why are you making this change? Provide a short description or bulleted list.

https://opendoor.atlassian.net/browse/DEVXP-1049

I'm seeing some strange behavior in the Athena deploy pipeline, which was recently changed to use our git-resource [fork](https://github.com/opendoor-labs/git-resource) instead of [the upstream](https://github.com/concourse/git-resource), and I never saw this issue when we were using the upstream.

in the pipeline, we use path filtering [here](https://github.com/opendoor-labs/code/blob/a4e70e45/js/packages/athena/ci/pipeline/pipeline.yaml#L1411-L1419) so that only Athena-related change cause Athena to re-deploy

```
  - name: app
    source:
      branch: master
      paths:
        - js/packages/athena
        - protobuf
        - concourse/scripts/
      uri: https://github.com/opendoor-labs/code.git
```
however, this path filtering is no longer working. Athena has recently re-deployed on:
- [nothing but changes to cortex files](https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/athena/jobs/deploy-production/builds/5139)
- [some java changes](https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/athena/jobs/deploy-production/builds/5138)
- [some other unrelated changes](https://concourse.managed.services.opendoor.com/teams/engineering/pipelines/athena/jobs/deploy-production/builds/5136)
- 
i have a gut feeling that this unintended behavior can be attributed to the [hardcoded depth=1 here in the `check` step](https://github.com/opendoor-labs/git-resource/compare/0a2b7d7df059f6e06319768396e0ae7d3a73449c..bf286a1eaa7d7d638d5bcad9020a95685cd0a641#diff-f69828c393e1fc66f53254eb92f80592ad8472667ba37040ac052e710e5d19fcR74-R103) to achieve a shallow clone. this makes sense — if the resource check always has a depth of 1, then the `$lastCommit` is literally every change ever, so of course every path looks "touched"

## Test Plan

<!-- How have you tested this change, and what further testing will be done? What’s the riskiest part of this PR? How will you test and monitor that? -->
<!-- If your PR changes a Terraform file, include the terraform plan output or link before asking for code review. -->
<!-- If you're adding a SQL query, please paste the before/after EXPLAIN ANALYZE plan here. For visual changes, please include a screenshot or recording if possible. -->

Tag, release, update tag in Vault, monitor Athena pipeline

## Mitigation

<!-- Please estimate the potential impact of your change and how we can roll back or mitigate any issues that may arise. Are there feature flags or monitoring in place? -->

Unpublish the release and revert back to 2.0.0

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [x] I have checked that other PRs this PR depends on have already been deployed.
- [x] I can confirm that if this PR introduces a DB schema change, I have read the [data contract schema change run book](https://opendoor.atlassian.net/wiki/spaces/RDS/pages/2338488364/Data+Contract+schema+change+run+book) and have followed all the steps outlined in the wiki to ensure that the change aligns with the [data contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
