### PR TITLE
Fix shallow clone problem

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -11,6 +11,11 @@ source $(dirname $0)/common.sh
 # for jq
 PATH=/usr/local/bin:$PATH
 
+bin_dir="${0%/*}"
+if [ "${bin_dir#/}" == "$bin_dir" ]; then
+  bin_dir="$PWD/$bin_dir"
+fi
+
 payload="$(cat <&0)"
 
 load_pubkey "$payload"
@@ -79,10 +84,20 @@ else
   logInfo "BEGIN opendoor/git-resource assets/check ... about to call clone with depth : $depth"
   git clone --depth=$depth --single-branch $uri $branchflag $destination $tagflag
   logInfo "AFTER opendoor/git-resource assets/check ... clone done"
+  cd $destination
+
+  # We need to make sure that $ref (the previous version) is in the history. Otherwise the check
+  # below will fail and reverse will not be set to true. In addition, in a shallow clone, the
+  # oldest commit (i.e., the 500th), will basically be a commit that adds every file in the repo,
+  # which will result in this commit always passing the paths check. Hence, without this deepening,
+  # the oldest commit will always be returned as the next version.
+  if [ -n "$ref" ] && ! git cat-file -e "$ref"; then
+    "$bin_dir"/deepen_shallow_clone_until_ref_is_found_then_check_out 1 "$ref" "$tagflag"
+  fi
+
   # remaining rate limit
   rate_limit_json=$(curl https://api.github.com/rate_limit -H "Authorization: token $TOKEN" --silent)
   logInfo rate limit remaining : $(echo $rate_limit_json | jq -r '.rate.remaining')
-  cd $destination
 fi
 
 if [ -n "$ref" ] && git cat-file -e "$ref"; then


### PR DESCRIPTION
<!-- Content enclosed in HTML comments will not be rendered in the Markdown, and are intended to help guide you -->

## Context

Basically we do a shallow clone of 500 commits, and if the previous version isn't in that last 500 commits then concourse gets in a loop of running the pipeline on old, irrelevant commits. See the comment in the code for more details on why.

## Test Plan

Testing on the `qac` pipeline, which has this problem.

## Mitigation

<!-- Please estimate the potential impact of your change and how we can roll back or mitigate any issues that may arise. Are there feature flags or monitoring in place? -->

## Checklist

<!-- This is a checklist. To mark an item as complete, use [x]. See https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#task-lists -->

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to external documentation if necessary (READMEs, Confluence, etc.)
- [ ] I have checked that other PRs this PR depends on have already been deployed.
- [ ] I can confirm that if this PR introduces a DB schema change, I have read and followed all the steps outlined in the [Data Contract](https://docs.google.com/document/d/1g_ZZ8TU58Dh2Fn_6aNHktBUNdnBtYNuOyu3GY-kGHnk/edit#heading=h.o2ce6n1q3gpb).

<!-- This PR template is inherited from https://github.com/opendoor-labs/.github -->
